### PR TITLE
Pass -std=gnu99 for old compilers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,10 @@
 project('wavbreaker', 'c',
   version : '0.12',
-  default_options : ['warning_level=1'])
+  default_options: [
+    'c_std=c99',
+    'warning_level=1',
+  ],
+)
 
 subdir('po')
 


### PR DESCRIPTION
FreeBSD and OpenBSD still use GCC 4.2 on some non-x86 architectures (e.g., powerpc*, mips*, sparc*). Clang 3.6 and GCC 5.0 switched to C11 by default.