### PR TITLE
Supply a valid AppData ‘content_rating’ to fix #26

### DIFF
--- a/data/net.sourceforge.wavbreaker.appdata.xml
+++ b/data/net.sourceforge.wavbreaker.appdata.xml
@@ -3,7 +3,6 @@
 <component type="desktop-application">
   <id>net.sourceforge.wavbreaker</id>
   <metadata_license>FSFAP</metadata_license>
-  <content_rating>none</content_rating>
   <project_license>GPL-2.0+</project_license>
   <name>wavbreaker</name>
   <summary>GUI tool to split WAV, MP2 and MP3 files</summary>

--- a/data/net.sourceforge.wavbreaker.appdata.xml
+++ b/data/net.sourceforge.wavbreaker.appdata.xml
@@ -3,6 +3,7 @@
 <component type="desktop-application">
   <id>net.sourceforge.wavbreaker</id>
   <metadata_license>FSFAP</metadata_license>
+  <content_rating type="oars-1.1" />
   <project_license>GPL-2.0+</project_license>
   <name>wavbreaker</name>
   <summary>GUI tool to split WAV, MP2 and MP3 files</summary>


### PR DESCRIPTION
Validation with `appstreamcli` reports that this element must not have text content, which in this case was just `none` anyway.

After this PR:

```
$ appstreamcli validate --no-net --explain data/net.sourceforge.wavbreaker.appdata.xml
I: net.sourceforge.wavbreaker:9: description-first-word-not-capitalized
   The description line does not start with a capitalized word, project name or number.

I: net.sourceforge.wavbreaker:~: content-rating-missing
   This component has no `content_rating` tag to provide age rating information. You can generate
   the tag data online by answering a few questions at https://hughsie.github.io/oars/

✔ Validation was successful: infos: 2
```