### PR TITLE
Replacing custom cue file parsing with libcue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install --yes \
-            libgtk-3-dev libao-dev libmpg123-dev libvorbis-dev \
+            libgtk-3-dev libao-dev libmpg123-dev libvorbis-dev libcue-dev \
             meson ninja-build \
             gettext flatpak-builder
       - name: Install Snap dependencies
@@ -45,7 +45,7 @@ jobs:
         if: matrix.build_type == 'macos'
         run: |
           brew install \
-            gtk+3 libao mpg123 libvorbis \
+            gtk+3 libao mpg123 libvorbis libcue \
             meson ninja gettext
       - name: Build for ${{ matrix.build_type }}
         if: matrix.build_type != 'snap'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format mostly follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+* Added `libcue` library dependency
+
+### Fixed
+
+* Importing of track breaks via CUE file now works with any well formatted CUE file
+
 ## [0.16] -- 2022-12-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ macOS Packaging
 Note that the macOS package doesn't include the runtime dependencies by
 default, those are expected to be installed via Homebrew:
 
-    brew install gtk+3 libao mpg123
+    brew install gtk+3 libao mpg123 libcue
 
 
 Windows Packaging

--- a/meson.build
+++ b/meson.build
@@ -14,11 +14,12 @@ localedir = get_option('localedir')
 glib = dependency('glib-2.0')
 gtk3 = dependency('gtk+-3.0', version : '>= 3.22')
 ao = dependency('ao')
+libcue = dependency('libcue')
 
 cc = meson.get_compiler('c')
 libm = cc.find_library('m')
 
-core_deps = [glib, libm]
+core_deps = [glib, libm, libcue]
 gui_deps = [gtk3]
 ao_deps = [ao]
 format_deps = []

--- a/scripts/flatpak/net.sourceforge.wavbreaker.json
+++ b/scripts/flatpak/net.sourceforge.wavbreaker.json
@@ -16,6 +16,16 @@
             ]
         },
         {
+            "name": "libcue",
+            "buildsystem": "cmake",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/lipnitsk/libcue.git"
+                }
+            ]
+        },
+        {
             "name": "wavbreaker",
             "buildsystem": "meson",
             "sources": [

--- a/scripts/win32/Dockerfile
+++ b/scripts/win32/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /build
 
 WORKDIR /build
 
-RUN dnf -y install make mingw64-gcc mingw64-gtk3 diffutils findutils automake autoconf meson gettext libtool git wget bzip2 xz
+RUN dnf -y install make mingw64-gcc mingw64-gtk3 diffutils findutils automake autoconf meson gettext libtool git wget bzip2 xz bison flex cmake
 
 RUN git clone https://github.com/xiph/libao.git && \
     cd libao && \
@@ -45,4 +45,13 @@ RUN wget https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz && \
         --host=x86_64-w64-mingw32 \
         --enable-shared \
         --prefix=/usr/x86_64-w64-mingw32/sys-root/mingw/ && \
+    make install V=1
+
+RUN wget https://github.com/lipnitsk/libcue/archive/refs/tags/v2.3.0.tar.gz -O libcue-2.3.0.tar.gz && \
+    tar xvf libcue-2.3.0.tar.gz && \
+    cd libcue-2.3.0 && \
+    mingw64-cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr/x86_64-w64-mingw32/sys-root/mingw/ \
+        -DBUILD_SHARED_LIBS=true \
+        . && \
     make install V=1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ parts:
       stage-packages:
           - libao4
           - libmpg123-0
-          - libcue
+          - libcue2
 slots:
     wavbreaker-dbus-name:
         interface: dbus

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,9 +25,11 @@ parts:
           - ninja-build
           - libao-dev
           - libmpg123-dev
+          - libcue-dev
       stage-packages:
           - libao4
           - libmpg123-0
+          - libcue
 slots:
     wavbreaker-dbus-name:
         interface: dbus

--- a/src/cue.c
+++ b/src/cue.c
@@ -22,68 +22,31 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <libcue.h>
 
 gboolean
 cue_read_file(const char *cue_filename, TrackBreakList *list)
 {
     FILE *fp;
-    /* These buffers must have the same length */
-    char line_buf[1024];
-    char buf[1024];
-    int next_track = 1;
 
     fp = fopen(cue_filename, "r");
-    if (!fp) {
-        return FALSE;
-    }
+    if (!fp) return FALSE;
 
-    track_break_list_clear(list);
+    Cd *cd = cue_parse_file(fp);
+    int trackCount = cd_get_ntrack(cd);
 
-    /* Read the first line: FILE "foo.wav" WAVE */
-    if (!fgets(line_buf, sizeof(line_buf), fp)) {
-        fclose(fp);
-        return FALSE;
-    }
+    // Track numbers, not array elements
+    for (int i = 1; i <= trackCount; i++) {
+        Track *track = cd_get_track(cd, i);
+        if (!track) continue;
 
-    /* Check that it starts with FILE and ends with WAVE */
-    if (sscanf(line_buf, "FILE %s WAVE", buf) != 1) {
-        goto error;
-    }
-
-    while (!feof(fp)) {
-        int N;
-        int read;
-        guint offset;
-
-        read = fscanf(fp, "TRACK %02d AUDIO\n", &N);
-        if (feof(fp)) {
-            break;
-        }
-
-        if (read != 1 || N != next_track) {
-            goto error;
-        }
-
-        if (!fgets(line_buf, sizeof(line_buf), fp)) {
-            goto error;
-        }
-
-        read = sscanf(line_buf, "INDEX %02d %s", &N, buf);
-        if (read != 2 || N != 1) {
-            goto error;
-        }
-
-        offset = msf_time_to_offset(buf);
+        gulong offset = track_get_start(track);
         track_break_list_add_offset(list, TRUE, offset, NULL);
-
-        ++next_track;
     }
+
+    fclose(fp);
 
     return TRUE;
-
-error:
-    fclose(fp);
-    return FALSE;
 }
 
 static void
@@ -93,8 +56,8 @@ track_break_write_cue(int index, gboolean write, gulong start_offset, gulong end
 
     gchar *time = track_break_format_timestamp(start_offset, TRUE);
 
-    fprintf(fp, "TRACK %02d AUDIO\n", index + 1);
-    fprintf(fp, "INDEX 01 %s\n", time);
+    fprintf(fp, "\n\tTRACK %02d AUDIO\n", index + 1);
+    fprintf(fp, "\t\tINDEX 01 %s\n", time);
 
     g_free(time);
 }
@@ -108,6 +71,7 @@ cue_write_file(const char *cue_filename, const char *audio_filename, TrackBreakL
         return FALSE;
     }
 
+    fprintf(fp, "REM Generated with wavbreaker\n");
     fprintf(fp, "FILE \"%s\" WAVE\n", audio_filename);
 
     track_break_list_foreach(list, track_break_write_cue, fp);

--- a/src/cue.c
+++ b/src/cue.c
@@ -30,15 +30,27 @@ cue_read_file(const char *cue_filename, TrackBreakList *list)
     FILE *fp;
 
     fp = fopen(cue_filename, "r");
-    if (!fp) return FALSE;
+    if (!fp) {
+        g_warning("Error opening CUE file: %s", cue_filename);
+        return FALSE;
+    }
 
     Cd *cd = cue_parse_file(fp);
+    if (!cd) {
+        g_warning("Unable to parse CUE file: %s", cue_filename);
+        fclose(fp);
+        return FALSE;
+    }
+
     int trackCount = cd_get_ntrack(cd);
 
     // Track numbers, not array elements
     for (int i = 1; i <= trackCount; i++) {
         Track *track = cd_get_track(cd, i);
-        if (!track) continue;
+        if (!track) {
+            g_warning("Track %i information missing from CUE sheet", i);
+            continue;
+        }
 
         gulong offset = track_get_start(track);
         track_break_list_add_offset(list, TRUE, offset, NULL);


### PR DESCRIPTION
Addresses #28

The old implementation for cue file parsing did not attempt to adhere to spec. This meant  many cue files would simply not parse correctly and therefore would not create the intended track breaks.

Replacing said parsing with a more robust library designed for parsing cue files fixes many, if not all, of the parsing bugs thusfar discovered.