### PR TITLE
Migrate to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           mv -v wavbreaker_*.snap dist/
       - uses: actions/upload-artifact@v4
         with:
-          name: build-result
+          name: build-result-${{ matrix.build_type }}
           path: dist/*
           if-no-files-found: ignore
       - name: Upload release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           mkdir -p dist/
           mv -v wavbreaker_*.snap dist/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-result
           path: dist/*


### PR DESCRIPTION
v3 has been deprecated in 2024: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/